### PR TITLE
Set the active power scheme after setting the brightness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.suo
+bin/
+obj/


### PR DESCRIPTION
The active power scheme must be set as the active power scheme after
setting the brightness to notify the system that the values have
changed. Otherwise the system may use a value different from what was
set.

Closes https://github.com/HubKing/LinkBrightness/pull/1

---

Hi thanks for creating this project. I had the same problem and searched for about an hour(!) before finding your solution. From all I've read there are a lot of people that find this behavior in Windows annoying. It's infuriating they didn't give us a way to disable it. Most of the solutions I read are plain wrong.

Your program works for me but only after fixing a bug in setting the brightness. As seen in [PowerWriteACValueIndex](https://msdn.microsoft.com/en-us/library/windows/desktop/aa372765.aspx) doc (also [PowerWriteDCValueIndex](https://msdn.microsoft.com/en-us/library/windows/desktop/aa372769.aspx))

> Changes to the settings for the active power scheme do not take effect until you call the [PowerSetActiveScheme](https://msdn.microsoft.com/en-us/library/windows/desktop/aa372758.aspx) function.

My commit changes SetBrightness to call that function. Without calling that function the brightness setting that is set may be used or it may not be used; it's really not guaranteed. For example on my Dell laptop let's say I set DC brightness to n, then your program sets AC brightness to n, and then I plug in and the brightness is set to (n - 10) and not n. n any number between 10 and 100. Here's an actual example, where I added for diag AC and DC values before and after:
~~~
==================================
Current power source: DC
AC brightness: 90
DC brightness: 100
Changing AC brightenss to 100.
AC brightness: 100
DC brightness: 100
==================================
Current power source: AC
AC brightness: 90
DC brightness: 100
Changing DC brightness to 90.
AC brightness: 90
DC brightness: 90
==================================
Current power source: AC
AC brightness: 100
DC brightness: 90
Changing DC brightness to 100.
AC brightness: 100
DC brightness: 100
==================================
Current power source: DC
AC brightness: 100
DC brightness: 90
Changing AC brightenss to 90.
AC brightness: 90
DC brightness: 90
==================================
Current power source: DC
AC brightness: 90
DC brightness: 100
Changing AC brightenss to 100.
AC brightness: 100
DC brightness: 100
==================================
Current power source: AC
AC brightness: 90
DC brightness: 100
Changing DC brightness to 90.
AC brightness: 90
DC brightness: 90
~~~
This is essentially undefined behavior, anything else could have happened or nothing at all. The solution of course is calling PowerSetActiveScheme with the already active scheme to let the system know that the values have changed.

Note you are using PowerGetActiveScheme but that requires calling LocalFree. I'm not sure how .NET gc handles a situation like that, whether it knows to call FreeHGlobal (which calls LocalFree) or it has some other default way of freeing intptr.

With regard to your todo statement in Start(), I didn't find a way to monitor for brightness changes other than WmiMonitorBrightnessEvent. You could probably poll with IOCTLs for legacy purposes but I think using Wmi events is better here. Though it appears at least on Windows 8.1 that there may not be an event depending on how the brightness is changed. For example when I change the brightness through advanced settings in the power profile there is no event sent after apply
![display brightness when changed through panel doesn t give notification after apply](https://user-images.githubusercontent.com/965580/31424811-528a3e28-ae2a-11e7-931b-25a4d4a258e3.png)
...but changing it via the slider gives notification after apply:
![display brightness changed through slider gives notification after apply](https://user-images.githubusercontent.com/965580/31424837-7a4b7580-ae2a-11e7-812c-0f1ea128c98e.PNG)
... and the main slider doesn't even need an apply, it changes it as soon as the slider is changed:
![display brightness changes as soon as the slider changes](https://user-images.githubusercontent.com/965580/31424852-8f9c4da6-ae2a-11e7-9164-72ec2d95f8bb.PNG)

Also I made a batch script to set the ac and dc brightness so i can just automate at the command line setbrightness 100 or setbrightness 0 etc
https://gist.github.com/jay/2c4ca23314f1ed31c24da390d86c2b23

